### PR TITLE
fix: check permission for Android 14

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -83,7 +83,7 @@ class MainApp extends StatelessWidget {
       final file = File('${tempDir.path}/$fileName')..writeAsBytesSync(response.bodyBytes);
       print('temp file path: ${file.path}');
       final permissionState = await PhotoManager.requestPermissionExtend();
-      if (!permissionState.isAuth) {
+      if (!permissionState.hasAccess) {
         Fluttertoast.showToast(msg: 'Please allow access and try again.');
         return;
       }


### PR DESCRIPTION
Android14で全て許可にした場合も、PermissionStateがLimitedで返ってくる模様
ドキュメントを見ると、`isAuth`ではなく`hasAccess`で判断すると良さそう

https://github.com/fluttercandies/flutter_photo_manager?tab=readme-ov-file#usage

```
final PermissionState ps = await PhotoManager.requestPermissionExtend(); // the method can use optional param `permission`.
if (ps.isAuth) {
  // Granted
  // You can to get assets here.
} else if (ps.hasAccess) {
  // Access will continue, but the amount visible depends on the user's selection.
} else {
  // Limited(iOS) or Rejected, use `==` for more precise judgements.
  // You can call `PhotoManager.openSetting()` to open settings for further steps.
}
```